### PR TITLE
Docker multi-stage build

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,27 +1,25 @@
-############################################################
-# Dockerfile to build OpenZWave Library container images
-# Based on CentOS7
-############################################################
-
-# Set the base image to Ubuntu
 FROM fishwaldo/qt-staticbuilds:5.12.4 as builder
 
-# File Author / Maintainer
 MAINTAINER Justin Hammond
 
-WORKDIR /opt
+RUN dnf -y update \
+ && dnf install -y rapidjson-devel \
+ && dnf clean all
 
-RUN dnf -y install rapidjson-devel
+WORKDIR /src
 RUN git clone https://github.com/qt/qtmqtt.git && cd qtmqtt && git checkout 5.12 && /opt/Qt/5.12.4/bin/qmake && make && make install
 RUN git clone https://github.com/OpenZWave/open-zwave.git && cd open-zwave && make -j4 && make install
 RUN git clone https://github.com/OpenZWave/qt-openzwave.git && cd qt-openzwave && git checkout mqtt && /opt/Qt/5.12.4/bin/qmake && make -j4 && make install
-#RUN ls -lah /usr/local/lib64/
-#RUN ls /opt/
-#RUN ls -lah /ozwdaemon/bin/
-#RUN LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH" /ozwdaemon/bin/ozwdaemon
-RUN mkdir /opt/ozw/ && mkdir /opt/ozw/config/
 
-ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
+FROM fedora:25
+
+RUN dnf -y update \
+ && dnf install -y libstdc++ \
+ && dnf clean all
+
+COPY --from=builder /ozwdaemon /ozwdaemon
+COPY --from=builder /usr/local/lib64/libopenzwave* /usr/lib64/
+
 ENV USBPATH="/dev/ttyUSB0"
 ENV MQTT_SERVER="localhost"
 ENV MQTT_PORT="1883"
@@ -29,4 +27,3 @@ WORKDIR /opt/ozw/
 EXPOSE 1983
 VOLUME ["/opt/ozw/config/"]
 ENTRYPOINT /usr/bin/catchsegv /ozwdaemon/bin/ozwdaemon -s $USBPATH -c /opt/ozw/config/ -u /opt/ozw/config/ --mqtt-server $MQTT_SERVER --mqtt-port $MQTT_PORT
-


### PR DESCRIPTION
Update the Dockerfile to perform a multi-stage build. This greatly reduces the final application image.

Qt-openzwave and its dependencies are installed and/or built in the 'builder' stage and the necessary application files are copied into a slimmer final image.

I pushed a test image to [here](https://hub.docker.com/layers/kpine/ozw-mqtt/test/images/sha256-94c065d4ebd8b6675da3028b9d3c23360bceb1404d32d09ea9e644699170dc57). Compressed it comes in at ~100MB compared to the official image which is more than 900MB.  Uncompressed on my system is ~300MB vs ~2.23GB.

