### PR TITLE
Use Binary Resource Files 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.cache
+Docker/Dockerfile
+**/*.o
+**/moc_*.cpp
+**/moc_*.o
+**/rep_*.cpp
+**/rep_*.o
+.qmake.stash
+qt-openzwavedatabase/config/**

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=builder /usr/local/lib/libqt* /usr/local/lib/
 COPY --from=builder /usr/local/lib*/libopenzwave* /usr/local/lib/
 COPY --from=builder /usr/lib/*/libQt5Mqtt* /usr/local/lib/
 COPY --from=builder /opt/qt-openzwave/tools/* /usr/local/bin/
+COPY --from=builder /usr/share/OpenZWave/qt-openzwavedatabase.rcc /usr/share/OpenZWave/
 RUN mkdir -p /opt/ozw/config/crashes/
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
 ENV USBPATH="/dev/ttyUSB0"

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@
 FROM debian:buster-slim as builder
 
 # File Author / Maintainer
-MAINTAINER Justin Hammond
+LABEL maintainer="justin@dynam.ac"
 
 WORKDIR /opt
 
@@ -17,18 +17,16 @@ ENV PATH=$PATH:/opt/depot_tools/
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git && mkdir breakpad && cd breakpad && fetch breakpad && cd src && ./configure --disable-processor && make && make install
 RUN git clone https://github.com/qt/qtmqtt.git && cd qtmqtt && git checkout 5.12 && /usr/lib/qt5/bin/qmake QT_BUILD_PARTS="libs tools" && make && make install
 RUN git clone https://github.com/OpenZWave/open-zwave.git && cd open-zwave && make -j4 && make install
-RUN git clone https://github.com/OpenZWave/qt-openzwave.git && cd qt-openzwave && /usr/lib/qt5/bin/qmake "CONFIG += BreakPad" && make -j4 && make install
-
-
+COPY . /opt/qt-openzwave/
+RUN cd qt-openzwave && if [ -f Makefile ]; then /usr/lib/qt5/bin/qmake -r; make distclean; fi && /usr/lib/qt5/bin/qmake -r "CONFIG+=BreakPad" &&  make -j4 && make install
+ 
 FROM debian:buster-slim
-MAINTAINER Justin Hammond
+
+LABEL maintainer="justin@dynam.ac"
+
 WORKDIR /opt
 
-RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease && echo 'deb     http://ftp.debian.org/debian/    unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list && echo 'deb     http://ftp.debian.org/debian/    experimental main contrib non-free' >> /etc/apt/sources.list.d/unstable.list && apt update
-RUN apt-get -y install libunwind8 libcurl4 
-RUN apt-get -y -t unstable install libqt5core5a libqt5network5
-RUN apt-get -y -t experimental install libqt5remoteobjects5
-
+RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease && echo 'deb     http://ftp.debian.org/debian/    unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list && echo 'deb     http://ftp.debian.org/debian/    experimental main contrib non-free' >> /etc/apt/sources.list.d/unstable.list && apt update && apt-get -y install libunwind8 libcurl4 && apt-get -y -t unstable install libqt5core5a libqt5network5 && apt-get -y -t experimental install libqt5remoteobjects5 && apt-get clean && rm -rf /var/lib/apt/lists/* && mkdir -p /opt/ozw/config/crashes/
 
 COPY --from=builder /usr/local/bin/* /usr/local/bin/
 COPY --from=builder /usr/local/lib/libqt* /usr/local/lib/

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ Running:
 -------------
 Start a container with the following command line:
 
-```docker run -it --device=/dev/ttyUSB0 -v /tmp/ozw:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USBPATH=/dev/ttyUSB0 openzwave/ozwdaemon:latest```
+```docker run -it --security-opt seccomp=unconfined --device=/dev/ttyUSB0 -v /tmp/ozw:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USBPATH=/dev/ttyUSB0 openzwave/ozwdaemon:latest```
 
 * replace MQTT_SERVER with the IP address of the MQTT Server 
 * replace all /dev/ttyUSB0 entries with the path to your USB Stick.
 * OpenZWave Config Files are copied on startup to the host directory specified by /tmp/ozw - You should replace it with a directory that is persistent. 
+
+the `--security-opt seccomp=unconfined` is needed to generate meaningfull
+backtraces, otherwise it will be difficult for us to debug.
 
 Please see [docs/MQTT.md](docs/MQTT.md) for further information
 

--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -1,13 +1,13 @@
 MQTT Client for OpenZWave
 =========================
 
-Docker Repo: https://hub.docker.com/r/openzwave/ozw-mqtt
+Docker Repo: https://hub.docker.com/r/openzwave/ozwdaemon
 
 Copy the "config" folder from OZW to `/tmp/ozw/`.
 
 Start a container with the following command line:
 ```
-docker run -it --device=/dev/ttyUSB0 -v /tmp/ozw:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USBPATH=/dev/ttyUSB0 openzwave/ozw-mqtt:latest
+docker run -it --security-opt seccomp=unconfined --device=/dev/ttyUSB0 -v /tmp/ozw:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USBPATH=/dev/ttyUSB0 openzwave/ozwdaemon:latest
 ```
 
 (replace `MQTT_SERVER` with the IP address of the MQTT Server and all `/dev/ttyUSB0` entries with the path to your USB Stick.

--- a/qt-openzwavedatabase/include/qt-openzwave/qt-openzwavedatabase.h
+++ b/qt-openzwavedatabase/include/qt-openzwave/qt-openzwavedatabase.h
@@ -2,6 +2,7 @@
 #define QTOPENZWAVEDATABASE_H
 #include <QDir>
 
+bool initConfigDatabase(QStringList paths);
 bool copyConfigDatabase(QDir configpath);
 
 #endif // QTOPENZWAVEDATABASE_H

--- a/qt-openzwavedatabase/qt-openzwavedatabase.pro
+++ b/qt-openzwavedatabase/qt-openzwavedatabase.pro
@@ -8,15 +8,16 @@ CONFIG += silent file_copies resources_big
 
 !versionAtLeast(QT_VERSION, 5.11.2):error("Use at least Qt version 5.11.2")
 
-ozwconfig.target=config/qrc_ozwconfig.cpp
-ozwconfig.commands=cp -R ../../open-zwave/config config/ && cd config && $$[QT_INSTALL_BINS]/rcc -project -o ozwconfig.qrc && $$[QT_INSTALL_BINS]/rcc --name="ozwconfig" --root="/config/" ozwconfig.qrc -o qrc_ozwconfig.cpp
+ozwconfig.target=qt-openzwavedatabase.rcc
+ozwconfig.commands=cp -R ../../open-zwave/config config/ && cd config && $$[QT_INSTALL_BINS]/rcc -project -o ozwconfig.qrc && $$[QT_INSTALL_BINS]/rcc --name="ozwconfig" --root="/config/" ozwconfig.qrc --binary -o ../qt-openzwavedatabase.rcc
+ozwconfigdb.path = $$[QT_INSTALL_PREFIX]/share/OpenZWave/
+ozwconfigdb.files=qt-openzwavedatabase.rcc
 
 !win32 {
     QMAKE_EXTRA_TARGETS += ozwconfig
-    PRE_TARGETDEPS += config/qrc_ozwconfig.cpp
-    SOURCES += config/qrc_ozwconfig.cpp \
-           source/qt-openzwavedatabase.cpp
-
+    PRE_TARGETDEPS += qt-openzwavedatabase.rcc
+    SOURCES += source/qt-openzwavedatabase.cpp
+    INSTALLS += ozwconfigdb
     macx {
         QMAKE_LFLAGS_SONAME = -Wl,-install_name,@rpath/
     }

--- a/qt-openzwavedatabase/qt-openzwavedatabase.pro
+++ b/qt-openzwavedatabase/qt-openzwavedatabase.pro
@@ -10,7 +10,7 @@ CONFIG += silent file_copies resources_big
 
 ozwconfig.target=qt-openzwavedatabase.rcc
 ozwconfig.commands=cp -R ../../open-zwave/config config/ && cd config && $$[QT_INSTALL_BINS]/rcc -project -o ozwconfig.qrc && $$[QT_INSTALL_BINS]/rcc --name="ozwconfig" --root="/config/" ozwconfig.qrc --binary -o ../qt-openzwavedatabase.rcc
-ozwconfigdb.path = $$[QT_INSTALL_PREFIX]/share/OpenZWave/
+ozwconfigdb.path=$$[QT_INSTALL_PREFIX]/share/OpenZWave/
 ozwconfigdb.files=qt-openzwavedatabase.rcc
 
 !win32 {

--- a/qt-openzwavedatabase/qt-openzwavedatabase.pro
+++ b/qt-openzwavedatabase/qt-openzwavedatabase.pro
@@ -9,28 +9,33 @@ CONFIG += silent file_copies resources_big
 !versionAtLeast(QT_VERSION, 5.11.2):error("Use at least Qt version 5.11.2")
 
 ozwconfig.target=qt-openzwavedatabase.rcc
-ozwconfig.commands=cp -R ../../open-zwave/config config/ && cd config && $$[QT_INSTALL_BINS]/rcc -project -o ozwconfig.qrc && $$[QT_INSTALL_BINS]/rcc --name="ozwconfig" --root="/config/" ozwconfig.qrc --binary -o ../qt-openzwavedatabase.rcc
-ozwconfigdb.path=$$[QT_INSTALL_PREFIX]/share/OpenZWave/
-ozwconfigdb.files=qt-openzwavedatabase.rcc
+ozwconfig.commands=@echo "Generating qt-openzwavedatabase.rcc" && cp -R ../../open-zwave/config config/ && cd config && $$[QT_INSTALL_BINS]/rcc -project -o ozwconfig.qrc && $$[QT_INSTALL_BINS]/rcc --name="ozwconfig" --root="/config/" ozwconfig.qrc --binary -o ../qt-openzwavedatabase.rcc
+
+ozwrccdb.path=$$[QT_INSTALL_PREFIX]/share/OpenZWave/
+ozwrccdb.files+=qt-openzwavedatabase.rcc
+ozwrccdb.CONFIG+=no_check_exist
+
+extraclean.commands=rm -rf config qt-openzwavedatabase.rcc
+clean.depends=extraclean
 
 !win32 {
-    QMAKE_EXTRA_TARGETS += ozwconfig
-    PRE_TARGETDEPS += qt-openzwavedatabase.rcc
     SOURCES += source/qt-openzwavedatabase.cpp
-    INSTALLS += ozwconfigdb
-    macx {
-        QMAKE_LFLAGS_SONAME = -Wl,-install_name,@rpath/
-    }
-
-
     HEADERS += \
         include/qt-openzwave/qt-openzwavedatabase.h
 
     INCLUDEPATH += include/
-    QMAKE_CXXFLAGS += -g1
+
     target.path = /usr/local/lib/
-    INSTALLS += target
+    QMAKE_EXTRA_TARGETS += clean extraclean ozwconfig
+    PRE_TARGETDEPS += qt-openzwavedatabase.rcc
+    INSTALLS+=target ozwrccdb
+    QMAKE_STRIP=@echo
+    QMAKE_CXXFLAGS += -g1
     QMAKE_CXXFLAGS += -g1
     QMAKE_LFLAGS += -rdynamic
+
+    macx {
+        QMAKE_LFLAGS_SONAME = -Wl,-install_name,@rpath/
+    }
 }
 

--- a/qt-openzwavedatabase/source/qt-openzwavedatabase.cpp
+++ b/qt-openzwavedatabase/source/qt-openzwavedatabase.cpp
@@ -1,6 +1,42 @@
 #include <QDirIterator>
 #include <QDebug>
+#include <QResource>
+#include <QStandardPaths>
 #include "qt-openzwave/qt-openzwavedatabase.h"
+
+bool initConfigDatabase(QStringList path) {
+    for (int i = 0; i < path.size(); ++i) {
+        QString test = path.at(i);
+        test.append("/qt-openzwavedatabase.rcc");
+        qDebug() << "Testing " << test;
+        if (QResource::registerResource(test)) {
+            qInfo() << "Found qt-openzwavedatabase.rcc at " << test;
+            return true;
+        }
+    }
+    if (QResource::registerResource("qt-openzwavedatabase/qt-openzwavedatabase.rcc")) {
+        qInfo() << "Found qt-openzwavedatabase.rcc at qt-openzwavedatabase/qt-openzwavedatabase.rcc";
+        return true;
+    }
+    if (QResource::registerResource("./qt-openzwavedatabase.rcc")) {
+        qInfo() << "Found qt-openzwavedatabase.rcc at ./qt-openzwavedatabase.rcc";
+        return true;
+    }
+
+    for (int i = 0; i < QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).size(); ++i) {
+        QString test = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).at(i);
+        test.append("/OpenZWave/qt-openzwavedatabase.rcc");
+        qDebug() << "Testing Standard Paths" << test;
+        if (QResource::registerResource(test)) {
+            qInfo() << "Found qt-openzwavedatabase.rcc at " << test;
+            return true;
+        }
+    }
+
+    return true; 
+
+}
+
 
 bool copyConfigDatabase(QDir configpath)
 {

--- a/qt-ozwdaemon/main.cpp
+++ b/qt-ozwdaemon/main.cpp
@@ -248,7 +248,6 @@ int main(int argc, char *argv[])
     qDebug() << "userPath: " << userPath;
 
     QSettings settings(userPath.append("/ozwdaemon.ini"), QSettings::IniFormat);
-    exit(-1);
 
 #ifdef HAVE_MQTT
     if (parser.isSet(MQTTServer)) {

--- a/qt-ozwdaemon/main.cpp
+++ b/qt-ozwdaemon/main.cpp
@@ -219,7 +219,6 @@ int main(int argc, char *argv[])
         PossibleDBPaths << parser.value(userDir);
     PossibleDBPaths << "./config/";
     PossibleDBPaths <<  QDir::toNativeSeparators("../../../config/");
-//    PossibleDBPaths << settings.value("openzwave/UserPath", QDir::toNativeSeparators("../../../config/")).toString().append("/");
     PossibleDBPaths << QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
 
     foreach(path, PossibleDBPaths) {
@@ -235,20 +234,21 @@ int main(int argc, char *argv[])
         }
     }
 
-//    if (userPath.isEmpty()) {
-//        fputs(qPrintable("userPath is Not Set or Missing\n"), stderr);
-//        exit(-1);
-//    }
+
     if (dbPath.isEmpty()) {
-        copyConfigDatabase(QFileInfo("./").absoluteFilePath().append("/"));
-        dbPath = "./config/";
-        userPath = "./config/";
+        if (initConfigDatabase(PossibleDBPaths)) {
+            copyConfigDatabase(QFileInfo("./").absoluteFilePath().append("/"));
+            dbPath = "./config/";
+            userPath = "./config/";
+        } else {
+            qWarning() << "Cant find qt-openzwavedatabase.rcc";
+        }
     }
     qDebug() << "DBPath: " << dbPath;
     qDebug() << "userPath: " << userPath;
 
     QSettings settings(userPath.append("/ozwdaemon.ini"), QSettings::IniFormat);
-
+    exit(-1);
 
 #ifdef HAVE_MQTT
     if (parser.isSet(MQTTServer)) {

--- a/qt-ozwdaemon/qt-ozwdaemon.pro
+++ b/qt-ozwdaemon/qt-ozwdaemon.pro
@@ -145,7 +145,7 @@ unix {
     QMAKE_CXXFLAGS += -g
     QMAKE_CFLAGS += -g
     QMAKE_LFLAGS += -rdynamic
-	QMAKE_STRIP = echo
+    QMAKE_STRIP = echo
 }
 win32 {
     LIBS += -lDnsapi -L../qt-openzwave/$$BUILDTYPE/ -lqt-openzwave1


### PR DESCRIPTION
Compiling our openzwave database into the executable was exceeding the memory limits on 32 bit systems (armhf) and thus wouldn't work. This now uses the QT binary files instead. 