### PR TITLE
Change USBPATH to USB_PATH to keep it consistent with the other env variables

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -12,14 +12,14 @@ LABEL maintainer="justin@dynam.ac"
 WORKDIR /opt
 
 RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease && echo 'deb     http://ftp.debian.org/debian/    unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list && echo 'deb     http://ftp.debian.org/debian/    experimental main contrib non-free' >> /etc/apt/sources.list.d/unstable.list && apt update
-RUN apt-get -y install rapidjson-dev git g++ cmake make pkgconf bash python wget joe mc libunwind-dev libcurl4-openssl-dev && apt-get -y -t unstable install qt5-default && apt-get -y -t unstable install qtbase5-private-dev && apt-get -y -t unstable install g++ && apt-get -y -t experimental install libqt5remoteobjects5-dev libqt5remoteobjects5-bin 
+RUN apt-get -y install rapidjson-dev git g++ cmake make pkgconf bash python wget joe mc libunwind-dev libcurl4-openssl-dev && apt-get -y -t unstable install qt5-default && apt-get -y -t unstable install qtbase5-private-dev && apt-get -y -t unstable install g++ && apt-get -y -t experimental install libqt5remoteobjects5-dev libqt5remoteobjects5-bin
 ENV PATH=$PATH:/opt/depot_tools/
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git && mkdir breakpad && cd breakpad && fetch breakpad && cd src && ./configure --disable-processor && make && make install
 RUN git clone https://github.com/qt/qtmqtt.git && cd qtmqtt && git checkout 5.12 && /usr/lib/qt5/bin/qmake QT_BUILD_PARTS="libs tools" && make && make install
 RUN git clone https://github.com/OpenZWave/open-zwave.git && cd open-zwave && make -j4 && make install
 COPY . /opt/qt-openzwave/
 RUN cd qt-openzwave && if [ -f Makefile ]; then /usr/lib/qt5/bin/qmake -r; make distclean; fi && /usr/lib/qt5/bin/qmake -r "CONFIG+=BreakPad" &&  make -j4 && make install
- 
+
 FROM debian:buster-slim
 
 LABEL maintainer="justin@dynam.ac"
@@ -36,7 +36,7 @@ COPY --from=builder /opt/qt-openzwave/tools/* /usr/local/bin/
 COPY --from=builder /usr/share/qt5/qt-openzwavedatabase.rcc /usr/share/qt5/
 RUN mkdir -p /opt/ozw/config/crashes/
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
-ENV USBPATH="/dev/ttyUSB0"
+ENV USB_PATH="/dev/ttyUSB0"
 ENV MQTT_SERVER="localhost"
 ENV MQTT_PORT="1883"
 ENV OZW_INSTANCE="1"
@@ -44,4 +44,4 @@ ENV BP_DB_PATH="/opt/ozw/config/crashes/"
 WORKDIR /opt/ozw/
 EXPOSE 1983
 VOLUME ["/opt/ozw/config/"]
-ENTRYPOINT /usr/local/bin/ozwdaemon -s $USBPATH -c /opt/ozw/config/ -u /opt/ozw/config/ --mqtt-server $MQTT_SERVER --mqtt-port $MQTT_PORT --stop-on-failure --mqtt-instance $OZW_INSTANCE
+ENTRYPOINT /usr/local/bin/ozwdaemon -s $USB_PATH -c /opt/ozw/config/ -u /opt/ozw/config/ --mqtt-server $MQTT_SERVER --mqtt-port $MQTT_PORT --stop-on-failure --mqtt-instance $OZW_INSTANCE

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Running:
 -------------
 Start a container with the following command line:
 
-```docker run -it --security-opt seccomp=unconfined --device=/dev/ttyUSB0 -v /tmp/ozw:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USBPATH=/dev/ttyUSB0 openzwave/ozwdaemon:latest```
+```docker run -it --security-opt seccomp=unconfined --device=/dev/ttyUSB0 -v /tmp/ozw:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USB_PATH=/dev/ttyUSB0 openzwave/ozwdaemon:latest```
 
 * replace MQTT_SERVER with the IP address of the MQTT Server 
 * replace all /dev/ttyUSB0 entries with the path to your USB Stick.

--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -13,7 +13,7 @@ printf "0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0b,0x0c,0x0d,0x0e,0x
 
 Start a container with the following command line:
 ```
-docker run -it --security-opt seccomp=unconfined --device=/dev/ttyUSB0 -v /home/ozw/config:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USBPATH=/dev/ttyUSB0 --secret OZW_Network_Key openzwave/ozwdaemon:latest
+docker run -it --security-opt seccomp=unconfined --device=/dev/ttyUSB0 -v /home/ozw/config:/opt/ozw/config -e MQTT_SERVER="10.100.200.102" -e USB_PATH=/dev/ttyUSB0 --secret OZW_Network_Key openzwave/ozwdaemon:latest
 ```
 
 * Update `MQTT_SERVER` with the IP address of the MQTT Server and all `/dev/ttyUSB0` entries with the path to your USB Stick.


### PR DESCRIPTION
The other variables I'm aware of are:
MQTT_SERVER
MQTT_PORT
OZW_NETWORK_KEY
OZW_INSTANCE
LD_LIBRARY_PATH
BP_DB_PATH

In order to keep them consistent I would like to change USBPATH to USB_PATH as this has already caused me confusion as seen in #32 

Cheers,