### PR TITLE
Update link to Home Assistant custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a [QT](https://www.qt.io) Wrapper for OpenZWave and contains ozwdaemon -
 </p>
   
 
-A [Docker Container](https://hub.docker.com/r/openzwave/ozwdaemon) to connect to the [new Z-Wave Integration for Home Assistant - python-openzwave-mqtt](https://github.com/cgarwood/python-openzwave-mqtt)
+A [Docker Container](https://hub.docker.com/r/openzwave/ozwdaemon) to connect to the [new Z-Wave Integration for Home Assistant - python-openzwave-mqtt](https://github.com/cgarwood/homeassistant-zwave_mqtt)
 
 Running:
 -------------


### PR DESCRIPTION
The README linked to the Python package that we use to represent Open Z-Wave from MQTT messages. Updated the link to the Home Assistant integration that uses that package instead. 