### PR TITLE
Strip abi version from libQt5Core

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -26,7 +26,19 @@ LABEL maintainer="justin@dynam.ac"
 
 WORKDIR /opt
 
-RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease && echo 'deb     http://ftp.debian.org/debian/    unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list && echo 'deb     http://ftp.debian.org/debian/    experimental main contrib non-free' >> /etc/apt/sources.list.d/unstable.list && apt update && apt-get -y install libunwind8 libcurl4 && apt-get -y -t unstable install libqt5core5a libqt5network5 libqt5websockets5 && apt-get -y -t experimental install libqt5remoteobjects5 && apt-get clean && rm -rf /var/lib/apt/lists/* && mkdir -p /opt/ozw/config/crashes/
+RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease \
+    && echo 'deb http://ftp.debian.org/debian/ unstable main contrib non-free' > /etc/apt/sources.list.d/unstable.list \
+    && echo 'deb http://ftp.debian.org/debian/ experimental main contrib non-free' >> /etc/apt/sources.list.d/unstable.list \
+    && apt update \
+    && apt-get -y install libunwind8 libcurl4 binutils \
+    && apt-get -y -t unstable install libqt5core5a libqt5network5 libqt5websockets5 \
+    && apt-get -y -t experimental install libqt5remoteobjects5 \
+    && strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 \
+    && apt-get -y purge binutils \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /opt/ozw/config/crashes/
 
 COPY --from=builder /usr/local/bin/* /usr/local/bin/
 COPY --from=builder /usr/lib/*/libqt-* /usr/local/lib/

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -33,7 +33,7 @@ RUN echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease
     && apt-get -y install libunwind8 libcurl4 binutils \
     && apt-get -y -t unstable install libqt5core5a libqt5network5 libqt5websockets5 \
     && apt-get -y -t experimental install libqt5remoteobjects5 \
-    && strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 \
+    && strip --remove-section=.note.ABI-tag /usr/lib/*/libQt5Core.so.5 \
     && apt-get -y purge binutils \
     && apt-get -y autoremove \
     && apt-get clean \


### PR DESCRIPTION
Strip abi-version tag from `libQt5Core.so.5`, fixes #37.