### PR TITLE
Update startup script, dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -57,4 +57,4 @@ ENV BP_DB_PATH="/opt/ozw/config/crashes/"
 WORKDIR /opt/ozw/
 EXPOSE 1983
 VOLUME ["/opt/ozw/config/"]
-ENTRYPOINT /startozwdaemon.sh
+ENTRYPOINT ["/startozwdaemon.sh"]

--- a/Docker/startozwdaemon.sh
+++ b/Docker/startozwdaemon.sh
@@ -1,57 +1,32 @@
 #!/bin/bash
 shopt -s nocaseglob
-if [ ! -c "$USB_PATH" ]
-then
+OZW_ARGS=()
+if [ ! -c "${USB_PATH:=/dev/ttyUSB0}" ]; then
 	echo "USB Path \"$USB_PATH\" does not exist or is not a Character Device"
 	exit 128
 else
-	CMD="-s $USB_PATH"
+	OZW_ARGS+=(-s "$USB_PATH")
+fi
+OZW_ARGS+=(--config-dir "${OZW_CONFIG_DIR:-/opt/ozw/config}")
+OZW_ARGS+=(--user-dir "${OZW_USER_DIR:-/opt/ozw/config}")
+OZW_ARGS+=(--mqtt-server "${MQTT_SERVER:-localhost}")
+OZW_ARGS+=(--mqtt-port "${MQTT_PORT:-1883}")
+if [[ "${STOP_ON_FAILURE:=true}" == true ]]; then
+	OZW_ARGS+=(--stop-on-failure)
+elif [[ "$STOP_ON_FAILURE" != "false" ]]; then
+	echo "Invalid value for STOP_ON_FAILURE: \"$STOP_ON_FAILURE\", expected true or false."
+	exit 1
+fi
+if [[ "${MQTT_TLS:=false}" == true ]]; then
+	OZW_ARGS+=(--mqtt-tls)
+elif [[  "$MQTT_TLS" != false ]]; then
+	echo "Invalid value for MQTT_TLS: \"$MQTT_TLS\", expected true or false."
+	exit 1
+fi
+OZW_ARGS+=(--mqtt-instance "${OZW_INSTANCE:-1}")
+if [ ! -z "${MQTT_USERNAME}" ]; then
+	OZW_ARGS+=(--mqtt-username "$MQTT_USERNAME")
 fi
 
-if [ ! -z "$MQTT_SERVER" ]
-then
-	CMD+=" --mqtt-server $MQTT_SERVER"
-	if [ ! -z "$MQTT_PORT" ]
-	then
-		CMD+=" --mqtt-port $MQTT_PORT"
-	else
-		CMD+=" --mqtt-port 1883"
-	fi
-fi
-	
-if [ -z "$STOP_ON_FAILURE" ]
-then
-	CMD+=" --stop-on-failure"
-else 
-	if [[ $STOP_ON_FAILURE != "false" ]]
-	then
-		CMD+=" --stop-on-failure"
-	fi
-fi
-
-if [ ! -z "$MQTT_TLS" ]
-then
-	if [[ $MQTT_TLS == "true" ]]
-	then
-		CMD+=" --mqtt-tls"
-	fi
-fi
-
-
-if [ -z "$OZW_INSTANCE" ] 
-then
-	CMD+=" --mqtt-instance 1"
-else 
-	CMD+=" --mqtt-instance $OZW_INSTANCE"
-fi
-
-if [ ! -z "$MQTT_USERNAME" ]
-then
-	CMD+=" --mqtt-username $MQTT_USERNAME"
-fi
-
-
-echo "Executing: /usr/local/bin/ozwdaemon $CMD"
-/usr/local/bin/ozwdaemon $CMD
-
-	
+echo "Executing: /usr/local/bin/ozwdaemon ${OZW_ARGS[@]} $@"
+exec /usr/local/bin/ozwdaemon "${OZW_ARGS[@]}" "$@"


### PR DESCRIPTION
Use exec form for entrypoint, pass cmd arguments on to `ozwdaemon`, use
exec to launch `ozwdaemon` to drop the shell to allow signals to be passed
on to the application.
Update startup script to allow whitespace in parameters, only allow
`true` and `false` as valid options for `STOP_ON_FAILURE` and `MQTT_TLS`.
Re-add config-dir, user-dir configuration.