### PR TITLE
Update mqtt node entry on name change

### DIFF
--- a/qt-ozwdaemon/mqttpublisher.cpp
+++ b/qt-ozwdaemon/mqttpublisher.cpp
@@ -615,6 +615,7 @@ void mqttpublisher::nodeReset(quint8 node) {
 }
 void mqttpublisher::nodeNaming(quint8 node) {
     qCDebug(ozwmp) << "Publishing Event nodeNaming:" << node;
+    this->m_nodeModel->populateJsonObject(*this->m_nodes[node], node, this->m_qtozwdaemon->getManager());
     QT2JS::SetString(*this->m_nodes[node], "Event", "nodeNaming");
     this->sendNodeUpdate(node);
 }


### PR DESCRIPTION
Currently when a name change event comes in for a node the even is updated in the MQTT node topic, but the actual data isn't update (`NodeName` in the json data). This allows for changes made to node names at run time (for example with ozw-admin) to propagate through to clients of the MQTT interface like Home Assistant without restarting.