### PR TITLE
Install all headers required by ozw-admin build

### DIFF
--- a/qt-openzwave/qt-openzwave.pro
+++ b/qt-openzwave/qt-openzwave.pro
@@ -79,6 +79,7 @@ PUBLIC_HEADERS.files += include/qt-openzwave/qtopenzwave.h \
 	include/qt-openzwave/rep_qtozwoptions_source.h \
 	include/qt-openzwave/websocketiodevice.h
 
+PUBLIC_HEADERS.CONFIG += no_check_exist
 
 HEADERS += $$PUBLIC_HEADERS.files
 

--- a/qt-openzwavedatabase/qt-openzwavedatabase.pro
+++ b/qt-openzwavedatabase/qt-openzwavedatabase.pro
@@ -37,7 +37,10 @@ clean.depends=extraclean
 
 
 SOURCES += source/qt-openzwavedatabase.cpp
-HEADERS += include/qt-openzwave/qt-openzwavedatabase.h
+
+PUBLIC_HEADERS.files += include/qt-openzwave/qt-openzwavedatabase.h
+
+HEADERS += $$PUBLIC_HEADERS.files
 
 INCLUDEPATH += include/
 isEmpty(PREFIX) {
@@ -49,7 +52,7 @@ isEmpty(LIBDIR) {
     target.path = $$PREFIX/$$LIBDIR
 }	
 isEmpty(INCDIR) {
-    PUBLIC_HEADERS.path = $$[QT_INSTALL_HEADERS]/$$TARGET/
+    PUBLIC_HEADERS.path = $$[QT_INSTALL_HEADERS]/qt-openzwave/
 } else {
     PUBLIC_HEADERS.path = $$PREFIX/$$INCDIR
 }


### PR DESCRIPTION
Currently not all headers required to build ozw-admin from a packaged qt-openzwave installation. This puts headers where ozw-admin expects them. In case of qt-openzwavedatabase this might not be the best option, adding an additional pkg-config file and using that might be better. 