### PR TITLE
Prevent docker build layer cache invalidation

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -50,7 +50,13 @@ RUN git clone https://github.com/OpenZWave/open-zwave.git \
 	&& make -j${concurrency} \
 	&& make install instlibdir=/usr/local/lib/
 
-COPY . /opt/qt-openzwave/
+COPY .qmake.conf /opt/qt-openzwave/
+COPY qt-openzwave /opt/qt-openzwave/qt-openzwave
+COPY qt-openzwave.pri /opt/qt-openzwave/
+COPY qt-openzwave.pro /opt/qt-openzwave/
+COPY qt-openzwavedatabase /opt/qt-openzwave/qt-openzwavedatabase
+COPY qt-ozwdaemon /opt/qt-openzwave/qt-ozwdaemon
+COPY qt-openzwave.pro /opt/qt-openzwave/
 
 ARG BP_CLIENTID
 ARG BP_CLIENTKEY


### PR DESCRIPTION
The Dockerfile is including all files in the project, which means
touching *any* file in the project (README, docs, docker root files,
etc) invalidates practically all of the cached docker layers and
triggers a rebuild of all libraries and applications.

Manually copy the needed files instead of the entire project. Note that
using .dockerignore alone is not possible because it would prevent
copying some files into the image that are necessary but unrelated to
the application builds.