### PR TITLE
Correctly set Button value types (#139)

### DIFF
--- a/qt-openzwave/source/qtozwmanager_p.cpp
+++ b/qt-openzwave/source/qtozwmanager_p.cpp
@@ -2205,7 +2205,12 @@ void QTOZWManager_Internal::pvt_valueModelDataChanged(const QModelIndex &topLeft
             }
             case OpenZWave::ValueID::ValueType_Button:
             {
-                this->m_manager->SetValue(vid, topLeft.data().toBool());
+                if (topLeft.data().toBool()) {
+                    this->m_manager->PressButton(vid);
+                }
+                else {
+                    this->m_manager->ReleaseButton(vid);
+                }
                 return;
             }
             case OpenZWave::ValueID::ValueType_Raw:


### PR DESCRIPTION
Use PressButton/ReleaseButton manager API instead of trying to set a boolean value.

Set Button to true:
```
2020-07-30 04:45:17.818486720  [20200729 21:45:17.818 PDT] [ozw.mqtt.commands] [debug]: Got  "OpenZWave/2/command/setvalue/"  Message:  "{\n  \"ValueIDKey\": 1688849925062680,\n  \"Value\": true\n}"
2020-07-30 04:45:17.818664057  [20200729 21:45:17.818 PDT] [ozw.mqtt.commands.setValue] [info]: Setting  1688849925062680  to Value  QVariant(bool, true)
2020-07-30 04:45:17.818820548  [20200729 21:45:17.818 PDT] [ozw.values] [debug]: setData Called for Row 85  With Value QVariant(bool, true)                                                                                                                                      2020-07-30 04:45:17.818880797  [20200729 21:45:17.818 PDT] [ozw.values] [debug]: valueModel Changed! QTOZW_ValueIds::Value - 85 :  QVariant(bool, true)
2020-07-30 04:45:17.818933876  [20200729 21:45:17.818 PDT] [ozw.values] [debug]: valueModel Changed! vidKey: 1688849925062680 QVariant(bool, true)
2020-07-30 04:45:17.819002716  [20200729 21:45:17.818 PDT] [ozw.library] [info]: Info - Node: 3 Value::Set - COMMAND_CLASS_POWERLEVEL - Test - 6 - 1 - true                                                                                                                      2020-07-30 04:45:17.819063039  [20200729 21:45:17.819 PDT] [ozw.library] [info]: Info - Node: 3 Running a Power Level Test: Target Node = 0, Power Level = Normal, Number of Frames = 0
2020-07-30 04:45:17.819126830  [20200729 21:45:17.819 PDT] [ozw.library] [debug]: Detail - Node: 3 Queuing (Send) PowerlevelCmd_TestNodeSet (Node=3): 0x01, 0x0d, 0x00, 0x13, 0x03, 0x06, 0x73, 0x04, 0x00, 0x00, 0x00, 0x00, 0x25, 0x3e, 0x88
2020-07-30 04:45:17.820023905  [20200729 21:45:17.819 PDT] [ozw.library] [info]: Info - Node: 3 Sending (Send) message (Callback ID=0x3e, Expected Reply=0x04) - PowerlevelCmd_TestNodeSet (Node=3): 0x01, 0x0d, 0x00, 0x13, 0x03, 0x06, 0x73, 0x04, 0x00, 0x00, 0x00, 0x00, 0x25, 0x3e, 0x88
```

Set Button to false:
```
2020-07-30 04:46:10.776799353  [20200729 21:46:10.776 PDT] [ozw.mqtt.commands] [debug]: Got  "OpenZWave/2/command/setvalue/"  Message:  "{\n  \"ValueIDKey\": 1688849925062680,\n  \"Value\": false\n}"
2020-07-30 04:46:10.777059221  [20200729 21:46:10.777 PDT] [ozw.mqtt.commands.setValue] [info]: Setting  1688849925062680  to Value  QVariant(bool, false)
2020-07-30 04:46:10.777167346  [20200729 21:46:10.777 PDT] [ozw.values] [debug]: setData Called for Row 85  With Value QVariant(bool, false)
2020-07-30 04:46:10.777310494  [20200729 21:46:10.777 PDT] [ozw.values] [debug]: valueModel Changed! QTOZW_ValueIds::Value - 85 :  QVariant(bool, false)
2020-07-30 04:46:10.777393391  [20200729 21:46:10.777 PDT] [ozw.values] [debug]: valueModel Changed! vidKey: 1688849925062680 QVariant(bool, false)
2020-07-30 04:46:10.777481971  [20200729 21:46:10.777 PDT] [ozw.library] [info]: Info - Node: 3 Value::Set - COMMAND_CLASS_POWERLEVEL - Test - 6 - 1 - false
```