### PR TITLE
Added missing parameter for healnetwork.

### DIFF
--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -740,7 +740,7 @@ This is a list of Commands that the MQTT Client will accept and process. As ment
 
 **Params**:
 
-​    None
+​    "doreturnroute" - bool: Specifies whether to heal node return routes.
 
 **Returns**:
 


### PR DESCRIPTION
Added required field `doreturnroute` to `healnetwork` command.