### PR TITLE
correct the case for 'setvalue' MQTT documentation

### DIFF
--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -1076,7 +1076,7 @@ See Also:
 
 ​	This command sends a NIF (Not Information Frame) to the target device. 
 
-## setValue
+## setvalue
 
 This allows a MQTT Client to set a value on a Device. As OZW supports many different types of Values, you must ensure that the payload that you send matches the type of Value you are attempting to change (String, Integer etc)
 


### PR DESCRIPTION
missed by merge for issue #68