### PR TITLE
Allow customizing ozwd-admin port

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The container is configurable via several environment variables.
 * OZW_CONFIG_DIR - Set the path inside the container that points to the Device Database. Most users should not need to modify this. Defaults to `/opt/ozw/config`.
 * OZW_USER_DIR - Change the path where Network Specific Cache/Config Files are stored. Most users should not need to modify this. Defaults to `/opt/ozw/config`.
 * OZW_AUTH_KEY - Remote management (ozw-admin) authorization key. 
+* OZW_ADMIN_PORT - Remote management (ozw-admin) server port; defaults to 1983. 
 * STOP_ON_FAILURE - If true, ozwdaemon will exit when it detects any failure, such as the inability to connect to the MQTT broker, or open the Z-Wave Controller. Valid values are `true` or `false`. Defaults to `true`.
 * MQTT_TLS - If true, ozwdaemon will connect with TLS encryption to the MQTT broker. Valid values are `true` or `false`. Defaults to `false`.
 

--- a/qt-openzwave/include/qt-openzwave/qtozwmanager.h
+++ b/qt-openzwave/include/qt-openzwave/qtozwmanager.h
@@ -82,7 +82,7 @@ public:
     QTOZWManager(QObject *parent = nullptr);
     bool initilizeBase() override;
 #ifndef Q_OS_WASM
-    bool initilizeSource(bool enableServer);
+    bool initilizeSource(bool enableServer, int serverPort);
     bool initilizeSource(QRemoteObjectHost *) override { return false; }
 #endif
     bool initilizeReplica(QUrl remoteaddress);

--- a/qt-openzwave/source/qtozwmanager.cpp
+++ b/qt-openzwave/source/qtozwmanager.cpp
@@ -69,7 +69,7 @@ bool QTOZWManager::initilizeBase() {
     return true;
 }
 #ifndef Q_OS_WASM
-bool QTOZWManager::initilizeSource(bool enableServer) {
+bool QTOZWManager::initilizeSource(bool enableServer, int serverPort) {
     initilizeBase();
     this->setConnectionType(ConnectionType::Type::Local);
 
@@ -102,7 +102,7 @@ bool QTOZWManager::initilizeSource(bool enableServer) {
         QObject::connect(this->m_webSockServer, &QWebSocketServer::serverError, this, &QTOZWManager::serverError);
         QObject::connect(this->m_webSockServer, &QWebSocketServer::peerVerifyError, this, &QTOZWManager::peerVerifyError);
         QObject::connect(this->m_webSockServer, &QWebSocketServer::sslErrors, this, &QTOZWManager::sslErrors);
-        if (!this->m_webSockServer->listen(QHostAddress::Any, 1983)) {
+        if (!this->m_webSockServer->listen(QHostAddress::Any, serverPort)) {
             qCWarning(manager) << "Couldn't Start WebSocket Server Listening On Socket" << this->m_webSockServer->errorString();
             /* we continue on, just in case */
         } else {

--- a/qt-ozwdaemon/qtozwdaemon.cpp
+++ b/qt-ozwdaemon/qtozwdaemon.cpp
@@ -59,7 +59,8 @@ qtozwdaemon::qtozwdaemon(QString configPath, QString userPath, QObject *parent) 
     }
 
     QString AuthKey = qgetenv("OZW_AUTH_KEY");
-    
+    QString ServerPort = qgetenv("OZW_ADMIN_PORT");
+
     QFile ak_file("/run/secrets/OZW_Auth_Key");
     if (ak_file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         AuthKey = ak_file.readLine().trimmed();
@@ -79,7 +80,7 @@ qtozwdaemon::qtozwdaemon(QString configPath, QString userPath, QObject *parent) 
     connect(this->m_qtozwmanager, &QTOZWManager::readyChanged, this, &qtozwdaemon::QTOZW_Ready);
     connect(this->m_qtozwmanager, &QTOZWManager::nodeQueriesComplete, this, &qtozwdaemon::nodeQueriesComplete);
     
-    this->m_qtozwmanager->initilizeSource(true);
+    this->m_qtozwmanager->initilizeSource(true, ServerPort.isNull() ? 1983 : ServerPort.toInt());
     if (!NetworkKey.isEmpty()) {
         this->m_qtozwmanager->getOptions()->setNetworkKey(NetworkKey);
     }

--- a/qt-simpleclient/mainwindow.cpp
+++ b/qt-simpleclient/mainwindow.cpp
@@ -72,7 +72,7 @@ void MainWindow::startRemote(QString url) {
 }
 void MainWindow::startLocal(QString serialPort, bool startServer) {
     this->m_serialPort = serialPort;
-    this->m_qtozwmanager->initilizeSource(startServer);
+    this->m_qtozwmanager->initilizeSource(startServer, 1983);
     qDebug() << "startLocal: " << this->m_serialPort;
 }
 


### PR DESCRIPTION
For obscure reasons I need to run two `ozwd` instances with `network_mode = host`; thus I cannot use Docker to remap the ports.

Support specifying the port via an environment variable.