### PR TITLE
Document support for secrets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ The container is configurable via several environment variables.
 * MQTT_PASSWORD - The password used to connect to the MQTT broker, if needed.
 * MQTT_CONNECT_TIMEOUT - The number of seconds to wait for the MQTT broker to become available before starting ozwdaemon. If a connection cannot be made before the timeout expires the container will exit. Defaults to 30 seconds.
 * USB_PATH - The pathname of the USB stick/serial device file in the container. This value must match the name of the device that was mapped from the host with the Docker `--device` option. Defaults to `/dev/ttyUSB0`.
-* OZW_NETWORK_KEY - The Network Key to secure communications with your devices (that are included Securely) - DO NOT LOSE THIS KEY OTHERWISE YOU WILL HAVE TO REINCLUDE YOUR SECURED DEVICES. Defaults to no network key (secure inclusion not possible).
+* OZW_NETWORK_KEY - The Network Key to secure communications with your devices (that are included Securely) - DO NOT LOSE THIS KEY OTHERWISE YOU WILL HAVE TO REINCLUDE YOUR SECURED DEVICES. Defaults to no network key (secure inclusion not possible). Alternatively, for increased security, a Docker secret named OZW_Network_Key can be supplied instead.
 * OZW_INSTANCE - Multiple Z-Wave networks can run concurrently by starting an individual container for each network. To distinguish the networks, set this enviroment variable to a unique value for each container instance. This affects the base topic that is published to the MQTT broker - `OpenZWave/<OZW_INSTANCE>/#`. Defaults to `1`.
 * OZW_CONFIG_DIR - Set the path inside the container that points to the Device Database. Most users should not need to modify this. Defaults to `/opt/ozw/config`.
 * OZW_USER_DIR - Change the path where Network Specific Cache/Config Files are stored. Most users should not need to modify this. Defaults to `/opt/ozw/config`.
-* OZW_AUTH_KEY - Remote management (ozw-admin) authorization key. 
+* OZW_AUTH_KEY - Remote management (ozw-admin) authorization key. Alternatively, for increased security, a Docker secret named OZW_Auth_Key can be supplied instead.
 * STOP_ON_FAILURE - If true, ozwdaemon will exit when it detects any failure, such as the inability to connect to the MQTT broker, or open the Z-Wave Controller. Valid values are `true` or `false`. Defaults to `true`.
 * MQTT_TLS - If true, ozwdaemon will connect with TLS encryption to the MQTT broker. Valid values are `true` or `false`. Defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The container is configurable via several environment variables.
 * MQTT_SERVER - The IP address or hostname of the MQTT broker. Defaults to `localhost`.
 * MQTT_PORT - The port number of the MQTT broker. Defaults to `1883`.
 * MQTT_USERNAME - The username to use when connecting to the MQTT broker. Do not set for anonymous logins.
-* MQTT_PASSWORD - The password used to connect to the MQTT broker, if needed.
+* MQTT_PASSWORD - The password used to connect to the MQTT broker, if needed. Alternatively, for increased esecurity, a Docker secret named MQTT_PASSWORD can be supplied instead.
 * MQTT_CONNECT_TIMEOUT - The number of seconds to wait for the MQTT broker to become available before starting ozwdaemon. If a connection cannot be made before the timeout expires the container will exit. Defaults to 30 seconds.
 * USB_PATH - The pathname of the USB stick/serial device file in the container. This value must match the name of the device that was mapped from the host with the Docker `--device` option. Defaults to `/dev/ttyUSB0`.
 * OZW_NETWORK_KEY - The Network Key to secure communications with your devices (that are included Securely) - DO NOT LOSE THIS KEY OTHERWISE YOU WILL HAVE TO REINCLUDE YOUR SECURED DEVICES. Defaults to no network key (secure inclusion not possible). Alternatively, for increased security, a Docker secret named OZW_Network_Key can be supplied instead.


### PR DESCRIPTION
I try to avoid putting secrets into environment variables wherever it's supported.  I noticed that the source mention Docker secrets instead of the environment variables specified in this README.

I tried it and it works!  Here's the relevant snippets I found from the logs:

**OZW_NETWORK_KEY**
```
$ cat openzwave/logs/ozwdaemon/current | grep "Network Key"
2021-01-25 01:29:29.328442275  [20210125 1:29:29.328 UTC] [ozw.daemon] [warning]: Network Key Specified in Enviroment is Invalid
2021-01-25 01:29:29.328790712  [20210125 1:29:29.328 UTC] [ozw.daemon] [info]: Network Key From File is Valid - Using File
2021-01-25 01:29:29.328914045  [20210125 1:29:29.328 UTC] [ozw.daemon] [info]: We Have what appears to be a valid Network Key - Passing to OZW
2021-01-25 01:29:29.420419805  [20210125 1:29:29.420 UTC] [ozw.library] [info]: Info - Node: 0 Setting Up Provided Network Key for Secure Communications
```

**OZW_AUTH_KEY**
The auth key doesn't have as much logging as the network key, but it does have some.
```
$ cat openzwave/logs/ozwdaemon/current | grep "Authentication Key"
2021-01-25 01:29:29.329138524  [20210125 1:29:29.328 UTC] [ozw.daemon] [info]: Using Remote Authentication Key
```

**MQTT_PASSWORD**
There isn't any "positive" logging that confirms that the MQTT password has been picked up, but all of the "negative" logging that indicates problems includes the phrase "MQTT_PASSWORD" and I don't have any instances of that in my logs.  And, my MQTT broker logged a successful connection from OZW.
```
$ cat openzwave/logs/ozwdaemon/current | grep "MQTT_PASSWORD"
<nothing>
```

Thanks!