### PR TITLE
Add healthcheck to docker in case $USB_PATH goes away

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -160,4 +160,6 @@ EXPOSE 5901
 EXPOSE 7800
 VOLUME ["/opt/ozw/config/"]
 
+HEALTHCHECK CMD /bin/head $USB_PATH
+
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
It appears that the ozwdaemon doesn't handle the USB device going away.  I haven't tested this outside of docker, maybe it handles better with the container layer removed.

I'd be happy if the ozwdaemon exited with an error like it does if the MQTT server goes away but this healthcheck makes it easier to have something restart the container if it goes unhealthy. 

Before removing device:
```
root@9876af95778d:~# ls -l $USB_PATH 
crw-rw---- 1 root 16 166, 0 Jan 29 17:30 /dev/zwave
root@9876af95778d:/opt/ozw# head $USB_PATH
root@9876af95778d:/opt/ozw# 
```
after removing USB device
```
root@9876af95778d:~# ls -l $USB_PATH 
crw-rw---- 1 root 16 166, 0 Jan 29 17:30 /dev/zwave
root@9876af95778d:~# head $USB_PATH
head: cannot open '/dev/zwave' for reading: No such device
```
after re-inserting USB device
```
root@9876af95778d:~# ls -l $USB_PATH 
crw-rw---- 1 root 16 166, 0 Jan 29 17:30 /dev/zwave
root@9876af95778d:~# head $USB_PATH
head: cannot open '/dev/zwave' for reading: No such device
```


Related to #198